### PR TITLE
SEG-17

### DIFF
--- a/integrations/amplitude/HISTORY.md
+++ b/integrations/amplitude/HISTORY.md
@@ -1,3 +1,7 @@
+# 3.3.0 / 2019-10-04
+
+- Add support for trackProductsOnce setting, this will track all products at once.
+
 # 3.2.0 / 2019-08-27
 
 - Add support for unsetParamsReferrerOnNewSession setting

--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -51,6 +51,7 @@ var Amplitude = (module.exports = integration('Amplitude')
   .option('traitsToIncrement', [])
   .option('appendFieldsToEventProps', {})
   .option('unsetParamsReferrerOnNewSession', false)
+  .option('trackProductsOnce', false)
   .tag('<script src="' + src + '">'));
 
 /**

--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -287,8 +287,28 @@ Amplitude.prototype.orderCompleted = function(track) {
   var trackRevenuePerProduct = this.options.trackRevenuePerProduct;
   var revenueType = track.proxy('properties.revenueType');
   var revenue = track.revenue();
+  var trackProductsOnce = this.options.trackProductsOnce;
 
-  // Amplitude does not allow arrays of objects to as properties of events.
+  if (trackProductsOnce) {
+    var allProducts = [];
+    // products is object
+    var productKeys = Object.keys(products);
+    for (var index = 0; index < productKeys.length; index++) {
+      var eachProduct = new Track({ properties: products[index] });
+
+      allProducts.push({
+        productId: eachProduct.productId(),
+        sku: eachProduct.sku(),
+        name: eachProduct.name(),
+        price: eachProduct.price(),
+        quantity: eachProduct.quantity(),
+        category: eachProduct.category()
+      });
+    }
+    clonedTrack.properties.products = allProducts;
+    logEvent.call(this, new Track(clonedTrack), trackRevenuePerProduct);
+    return;
+  }
   // Our Order Completed event however uses a products array for product level tracking.
   // We need to remove this before logging the event and then use it to track revenue.
   delete clonedTrack.properties.products;

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -758,6 +758,53 @@ describe('Amplitude', function() {
         analytics.track('Order Completed');
         analytics.called(window.amplitude.getInstance().setDeviceId, 'example');
       });
+
+      it('should call logEvent once if `trackProductsOnce` is set', function() {
+        var spy = sinon.spy(window.amplitude.getInstance(), 'logEvent');
+        amplitude.options.trackProductsOnce = true;
+        analytics.track('Order Completed', payload);
+        analytics.assert(spy.calledOnce);
+      });
+
+      it('should track all product at once once if `trackProductsOnce` is set', function() {
+        analytics.stub(window.amplitude.getInstance(), 'logEvent');
+        amplitude.options.trackProductsOnce = true;
+        analytics.track('Order Completed', payload);
+        analytics.called(
+          window.amplitude.getInstance().logEvent,
+          'Order Completed',
+          {
+            checkoutId: 'fksdjfsdjfisjf9sdfjsd9f',
+            orderId: '50314b8e9bcf000000000000',
+            affiliation: 'Google Store',
+            total: 30,
+            revenue: 25,
+            shipping: 3,
+            tax: 2,
+            discount: 2.5,
+            coupon: 'hasbros',
+            currency: 'USD',
+            products: [
+              {
+                productId: '507f1f77bcf86cd799439011',
+                sku: '45790-32',
+                name: 'Monopoly: 3rd Edition',
+                price: 19,
+                quantity: 1,
+                category: 'Games'
+              },
+              {
+                productId: '505bd76785ebb509fc183733',
+                sku: '46493-32',
+                name: 'Uno Card Game',
+                price: 3,
+                quantity: 2,
+                category: 'Games'
+              }
+            ]
+          }
+        );
+      });
     });
 
     describe('#group', function() {


### PR DESCRIPTION
A customer wants to send a Order Completed event to Amplitude with all products attached to it. This is a functionality that Amplitude has added recently.

This feature should be opt-in, and by default, it shouldn't change the way that customers send the data.