### PR TITLE
DWEB-5 Allow support for data as object to be send as playload in event

### DIFF
--- a/integrations/appboy/HISTORY.md
+++ b/integrations/appboy/HISTORY.md
@@ -1,3 +1,8 @@
+1.13.1 / 2019-11-27
+===================
+
+* Add support for sending date as object in event payload.
+
 1.13.0 / 2019-09-04
 ===================
 

--- a/integrations/appboy/lib/index.js
+++ b/integrations/appboy/lib/index.js
@@ -330,7 +330,12 @@ Appboy.prototype.identify = function(identify) {
   // Remove nested hash objects as Braze only supports nested array objects in identify calls
   // https://segment.com/docs/destinations/braze/#identify
   each(function(value, key) {
-    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      !isDate(value)
+    ) {
       delete traits[key];
     }
   }, traits);
@@ -385,7 +390,7 @@ Appboy.prototype.track = function(track) {
     // Remove nested objects as Braze doesn't support objects in tracking calls
     // https://segment.com/docs/destinations/braze/#track
     each(function(value, key) {
-      if (value != null && typeof value === 'object') {
+      if (value != null && typeof value === 'object' && !isDate(value)) {
         delete properties[key];
       }
     }, properties);
@@ -552,7 +557,7 @@ function isValidProperty(name, value) {
     return true;
   }
 
-  if (typeof value === 'object' && value instanceof Date) {
+  if (isDate(value)) {
     return true;
   }
 
@@ -564,4 +569,15 @@ function isValidProperty(name, value) {
   }
 
   return false;
+}
+
+/**
+ * Validate date:
+ *
+ * @param {*} value Value of the property.
+ *
+ * @return {boolean} <code>true</code> if the value are valid, <code>false</code> otherwise.
+ */
+function isDate(value) {
+  return typeof value === 'object' && value instanceof Date;
 }

--- a/integrations/appboy/package.json
+++ b/integrations/appboy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/appboy/test/index.test.js
+++ b/integrations/appboy/test/index.test.js
@@ -369,6 +369,19 @@ describe('Appboy', function() {
         );
       });
 
+      it('should handle custom traits of valid types and including date object', function() {
+        var date = new Date();
+        analytics.identify('userId', {
+          date: date
+        });
+        analytics.called(window.appboy.changeUser, 'userId');
+        analytics.called(
+          window.appboy.ab.User.prototype.setCustomUserAttribute,
+          'date',
+          date
+        );
+      });
+
       it('should not let you set reserved keys as custom attributes', function() {
         analytics.identify('rick sanchez', {
           avatar: 'airbender',
@@ -428,6 +441,24 @@ describe('Appboy', function() {
             spiritAnimal: 'rihanna',
             best_friend: 'han',
             number_of_friends: 12
+          }
+        );
+      });
+
+      it('should send all properties including date object', function() {
+        var dob = new Date();
+        analytics.track('event with properties', {
+          nickname: 'noonz',
+          idols: ['beyonce', 'madonna'],
+          favoriteThings: { whiskers: 'on-kittins' },
+          dob: dob
+        });
+        analytics.called(
+          window.appboy.logCustomEvent,
+          'event with properties',
+          {
+            nickname: 'noonz',
+            dob: dob
           }
         );
       });


### PR DESCRIPTION
**What does this PR do?**
Added support for sending date as object in event payload for braze.

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
Braze don't have support for object to be send as event payload except date.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No.

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
https://www.braze.com/docs/developer_guide/platform_integration_guides/web/analytics/tracking_custom_events/