### PR TITLE
DWEB-13 reset custom dimension only if present

### DIFF
--- a/integrations/google-analytics/HISTORY.md
+++ b/integrations/google-analytics/HISTORY.md
@@ -1,3 +1,8 @@
+2.18.1 / 2019-12-23
+===================
+
+  * Added some more handling around resetting custom dimension.
+
 2.18.0 / 2019-12-17
 ===================
 

--- a/integrations/google-analytics/lib/index.js
+++ b/integrations/google-analytics/lib/index.js
@@ -241,7 +241,12 @@ GA.prototype.page = function(page) {
       resetCustomDimensions[opts.dimensions[property]] = null;
     }
   }
-  window.ga(self._trackerName + 'set', resetCustomDimensions);
+  if (
+    opts.resetCustomDimensionsOnPage.length &&
+    Object.keys(resetCustomDimensions).length
+  ) {
+    window.ga(self._trackerName + 'set', resetCustomDimensions);
+  }
 
   pageview = extend(
     pageview,
@@ -249,6 +254,7 @@ GA.prototype.page = function(page) {
   );
 
   if (pageReferrer !== document.referrer) payload.referrer = pageReferrer; // allow referrer override if referrer was manually set
+
   window.ga(this._trackerName + 'set', payload);
 
   if (this.pageCalled) delete pageview.location;

--- a/integrations/google-analytics/package.json
+++ b/integrations/google-analytics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-google-analytics",
   "description": "The Google Analytics analytics.js integration.",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/google-analytics/test/index.test.js
+++ b/integrations/google-analytics/test/index.test.js
@@ -416,6 +416,19 @@ describe('Google Analytics', function() {
           });
         });
 
+        it('should set page properties with path', function() {
+          ga.options.trackNamedPages = true;
+          analytics.page('Apply Form', {
+            title: 'GrowthLine Application Form',
+            url: 'https://apply.growthstreet.co.uk/apply',
+            path: '/apply'
+          });
+          analytics.called(window.ga, 'set', {
+            page: '/apply',
+            title: 'Apply Form'
+          });
+        });
+
         it('should not set custom dimensions/metrics if settings.setAllMappedProps is false', function() {
           ga.options.setAllMappedProps = false;
           ga.options.metrics = {
@@ -606,13 +619,11 @@ describe('Google Analytics', function() {
           analytics.page('Name');
           analytics.page('Category', 'Name');
           // send should only be sent twice, for pageviews, not events
-          analytics.assert(window.ga.args.length === 6);
+          analytics.assert(window.ga.args.length === 4);
           analytics.assert(window.ga.args[0][0] === 'set');
-          analytics.assert(window.ga.args[1][0] === 'set');
-          analytics.assert(window.ga.args[2][0] === 'send');
-          analytics.assert(window.ga.args[3][0] === 'set');
-          analytics.assert(window.ga.args[4][0] === 'set');
-          analytics.assert(window.ga.args[5][0] === 'send');
+          analytics.assert(window.ga.args[1][0] === 'send');
+          analytics.assert(window.ga.args[2][0] === 'set');
+          analytics.assert(window.ga.args[3][0] === 'send');
         });
 
         it('should reset custom dimensions before set', function() {


### PR DESCRIPTION
**What does this PR do?**
Added some more handling before resetting custom dimensions.

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
If not any custom dimension configured for google analytics still it's calling set event unnecessarily.

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No.

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
NA