### PR TITLE
DWEB-27

### DIFF
--- a/integrations/amplitude/HISTORY.md
+++ b/integrations/amplitude/HISTORY.md
@@ -1,3 +1,7 @@
+# 3.3.1 / 2020-03-06
+
+- Add support for specifying app version from context setting for identify, page and track events.
+
 # 3.3.0 / 2019-10-09
 
 - Add support for versionName setting, this will allow user to specify version.

--- a/integrations/amplitude/lib/index.js
+++ b/integrations/amplitude/lib/index.js
@@ -174,6 +174,11 @@ Amplitude.prototype.page = function(page) {
  */
 
 Amplitude.prototype.identify = function(identify) {
+  var appVersion = identify.proxy('context.app.version');
+  if (appVersion) {
+    window.amplitude.getInstance().setVersionName(appVersion);
+  }
+
   this.setDeviceIdFromAnonymousId(identify);
 
   var id = identify.userId();
@@ -239,6 +244,11 @@ Amplitude.prototype.setTraits = function(traits) {
 Amplitude.prototype.track = logEvent;
 
 function logEvent(track, dontSetRevenue) {
+  var appVersion = track.proxy('context.app.version');
+  if (appVersion) {
+    window.amplitude.getInstance().setVersionName(appVersion);
+  }
+
   this.setDeviceIdFromAnonymousId(track);
 
   var props = track.properties();

--- a/integrations/amplitude/package.json
+++ b/integrations/amplitude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/amplitude/test/index.test.js
+++ b/integrations/amplitude/test/index.test.js
@@ -216,6 +216,25 @@ describe('Amplitude', function() {
         analytics.stub(window.amplitude.getInstance(), 'logEvent');
         analytics.stub(window.amplitude.getInstance(), 'setUserProperties');
         analytics.stub(window.amplitude.getInstance(), 'setDeviceId');
+        analytics.stub(window.amplitude.getInstance(), 'setVersionName');
+      });
+
+      it('should set app version if specified in context', function() {
+        analytics.page(
+          'page',
+          {},
+          {
+            context: {
+              app: {
+                version: '1.2.3'
+              }
+            }
+          }
+        );
+        analytics.called(
+          window.amplitude.getInstance().setVersionName,
+          '1.2.3'
+        );
       });
 
       it('should not track unnamed pages by default', function() {
@@ -350,6 +369,7 @@ describe('Amplitude', function() {
         analytics.stub(window.amplitude.getInstance(), 'setUserProperties');
         analytics.stub(window.amplitude.getInstance(), 'setGroup');
         analytics.stub(window.amplitude.getInstance(), 'setDeviceId');
+        analytics.stub(window.amplitude.getInstance(), 'setVersionName');
       });
 
       it('should send an id', function() {
@@ -475,6 +495,24 @@ describe('Amplitude', function() {
         analytics.identify('id');
         analytics.called(window.amplitude.getInstance().setDeviceId, 'example');
       });
+
+      it('should set app version if specified in context', function() {
+        analytics.identify(
+          'id',
+          {},
+          {
+            context: {
+              app: {
+                version: '1.2.3'
+              }
+            }
+          }
+        );
+        analytics.called(
+          window.amplitude.getInstance().setVersionName,
+          '1.2.3'
+        );
+      });
     });
 
     describe('#track', function() {
@@ -485,6 +523,25 @@ describe('Amplitude', function() {
         analytics.stub(window.amplitude.getInstance(), 'logRevenueV2');
         analytics.stub(window.amplitude.getInstance(), 'logEventWithGroups');
         analytics.stub(window.amplitude.getInstance(), 'setDeviceId');
+        analytics.stub(window.amplitude.getInstance(), 'setVersionName');
+      });
+
+      it('should set app version if specified in context', function() {
+        analytics.track(
+          'event',
+          {},
+          {
+            context: {
+              app: {
+                version: '1.2.3'
+              }
+            }
+          }
+        );
+        analytics.called(
+          window.amplitude.getInstance().setVersionName,
+          '1.2.3'
+        );
       });
 
       it('should send an event', function() {


### PR DESCRIPTION
**What does this PR do?**
Add support for specifying app version in context object for identify, page and track events as supported in cloud mode. 

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
The customer has requested that the app object, containing version and other app information, to be supported in analytics.js Amplitude. 

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No

**Does this require a new integration setting? If so, please explain how the new setting works**
No

**Links to helpful docs and other external resources**
https://segment.com/docs/connections/destinations/catalog/amplitude/#setting-amplitude-version-user-property-using-identify