### PR TITLE
DWEB-42 added option for setting cookie domain while initializing

### DIFF
--- a/integrations/mixpanel/HISTORY.md
+++ b/integrations/mixpanel/HISTORY.md
@@ -1,3 +1,7 @@
+3.2.1 / 2020-03-18
+==================
+  * Added new setting for setting cookie domain while initializing.
+
 3.1.0 / 2019-09-27
 ==================
   * Added support for groups.

--- a/integrations/mixpanel/lib/index.js
+++ b/integrations/mixpanel/lib/index.js
@@ -40,6 +40,7 @@ var Mixpanel = (module.exports = integration('Mixpanel')
   .option('groupIdentifierTraits', [])
   .option('sourceName', '')
   .option('enableEuropeanUnionEndpoint', false)
+  .option('cookieDomain', '')
   .tag('<script src="//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js">'));
 
 /**
@@ -78,6 +79,10 @@ for(h=0;h<k.length;h++)e(d,k[h]);a._i.push([b,c,f])};a.__SV=1.2;}})(document,win
   options.loaded = function(mixpanel) {
     mixpanel.register({ mp_lib: 'Segment: web' });
   };
+  if (this.options.cookieDomain && this.options.cookieDomain.trim()) {
+    // Custom cookie domain (overrides value specified in this Mixpanel instance's config)
+    options.cookie_domain = this.options.cookieDomain.trim();
+  }
   window.mixpanel.init(options.token, options);
   this.load(this.ready);
 };

--- a/integrations/mixpanel/package.json
+++ b/integrations/mixpanel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-mixpanel",
   "description": "The Mixpanel analytics.js integration.",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/mixpanel/test/index.test.js
+++ b/integrations/mixpanel/test/index.test.js
@@ -19,7 +19,8 @@ describe('Mixpanel', function() {
     trackCategorizedPages: true,
     trackNamedPages: true,
     groupIdentifierTraits: [],
-    enableEuropeanUnionEndpoint: false
+    enableEuropeanUnionEndpoint: false,
+    cookieDomain: ''
   };
 
   beforeEach(function() {
@@ -58,6 +59,7 @@ describe('Mixpanel', function() {
         .option('groupIdentifierTraits', [])
         .option('sourceName', '')
         .option('enableEuropeanUnionEndpoint', false)
+        .option('cookieDomain', '')
     );
   });
 
@@ -97,6 +99,7 @@ describe('Mixpanel', function() {
 
   describe('after loading', function() {
     beforeEach(function(done) {
+      mixpanel.options.cookieDomain = 'abc.com';
       analytics.once('ready', done);
       analytics.initialize();
       analytics.page();
@@ -111,6 +114,12 @@ describe('Mixpanel', function() {
             .toString()
             .includes("{ mp_lib: 'Segment: web' }")
         );
+      });
+
+      it('should set cookie domain', function() {
+        analytics.initialize();
+        analytics.page();
+        analytics.deepEqual(window.mixpanel.config.cookie_domain, 'abc.com');
       });
     });
 


### PR DESCRIPTION
**What does this PR do?**
Option for setting cookie domain while initialising mixpanel. 

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
NA

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No.

**Does this require a new integration setting? If so, please explain how the new setting works**
Yes, option **cookieDomain** can be set as string.

**Links to helpful docs and other external resources**
https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanel.set_config