### PR TITLE
DWEB-43 Add support for nested property blacklisting for fb pixel

### DIFF
--- a/integrations/facebook-pixel/HISTORY.md
+++ b/integrations/facebook-pixel/HISTORY.md
@@ -1,3 +1,8 @@
+2.11.0/ 2020-03-24
+==================
+
+  * Add support for nested property blacklisting for fb pixel.
+
 2.10.0/ 2019-12-04
 ==================
 

--- a/integrations/facebook-pixel/package.json
+++ b/integrations/facebook-pixel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/facebook-pixel/test/index.test.js
+++ b/integrations/facebook-pixel/test/index.test.js
@@ -352,6 +352,86 @@ describe('Facebook Pixel', function() {
           assertEventId(window.fbq);
         });
 
+        it('should hash and send blacklisted nested properties if the hashProperty flag is true', function() {
+          facebookPixel.options.blacklistPiiProperties = [
+            {
+              propertyName: 'email',
+              hashProperty: true
+            },
+            {
+              propertyName: 'team.name',
+              hashProperty: true
+            }
+          ];
+          analytics.track('event', {
+            // PII
+            email: 'steph@warriors.com',
+            firstName: 'Steph',
+            lastName: 'Curry',
+
+            // Non PII
+            position: 'point guard',
+
+            // Not default PII but included in blacklist setting
+            team: { name: 'Warriors', id: 101 }
+          });
+
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {
+              team: {
+                name:
+                  '3fae3f8daeddc90e04e7502be791c0d149cbc8f0886d68037ad81b8bd61d029d'
+              },
+              email:
+                '6dd27a21704a843224245b20369e216eecd3a599b78c4489e5f6cabb5aeca24a',
+              position: 'point guard'
+            }
+          );
+          assertEventId(window.fbq);
+        });
+
+        it('should not hash and send blacklisted nested properties if the hashProperty flag is false', function() {
+          facebookPixel.options.blacklistPiiProperties = [
+            {
+              propertyName: 'email',
+              hashProperty: true
+            },
+            {
+              propertyName: 'team.name',
+              hashProperty: false
+            }
+          ];
+          analytics.track('event', {
+            // PII
+            email: 'steph@warriors.com',
+            firstName: 'Steph',
+            lastName: 'Curry',
+
+            // Non PII
+            position: 'point guard',
+
+            // Not default PII but included in blacklist setting
+            team: { name: 'Warriors', id: 101 }
+          });
+
+          analytics.called(
+            window.fbq,
+            'trackSingleCustom',
+            options.pixelId,
+            'event',
+            {
+              email:
+                '6dd27a21704a843224245b20369e216eecd3a599b78c4489e5f6cabb5aeca24a',
+              position: 'point guard'
+            }
+          );
+          assertEventId(window.fbq);
+        });
+
         it('should only attempt to hash string values', function() {
           facebookPixel.options.blacklistPiiProperties = [
             {


### PR DESCRIPTION
**What does this PR do?**
Add support for nested property blacklisting for fb pixel

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
NA

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
The problem is that Facebook will also detect PII violations for properties in objects nested within the Properties object but the Blacklist PII Properties setting does not allow for blacklisting at this level.

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
NA