### PR TITLE
DWEB-39 

### DIFF
--- a/integrations/pinterest-tag/HISTORY.md
+++ b/integrations/pinterest-tag/HISTORY.md
@@ -1,7 +1,12 @@
+1.2.3 / 2020-03-26
+==================
+
+  * Added support for product viewed event as PageVisit.
+
 1.2.2 / 2019-10-14
 ==================
 
-  * Add support for enhanced match. 
+  * Add support for enhanced match.
 
 1.2.1 / 2019-07-02
 ==================

--- a/integrations/pinterest-tag/lib/index.js
+++ b/integrations/pinterest-tag/lib/index.js
@@ -92,7 +92,8 @@ Pinterest.prototype.getPinterestEvent = function(segmentEvent) {
     [analyticsEvents.productListFiltered, 'Search'],
     [analyticsEvents.productAdded, 'AddToCart'],
     [analyticsEvents.orderCompleted, 'Checkout'],
-    [analyticsEvents.videoPlaybackStarted, 'WatchVideo']
+    [analyticsEvents.videoPlaybackStarted, 'WatchVideo'],
+    [analyticsEvents.productViewed, 'PageVisit']
   ];
 
   for (var index in eventMap) {

--- a/integrations/pinterest-tag/package.json
+++ b/integrations/pinterest-tag/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-pinterest-tag",
   "description": "The Pinterest Tag analytics.js integration.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -114,6 +114,116 @@ describe('Pinterest', function() {
           ]
         });
       });
+
+      it('should track custom event mapped under pinterestEventMapping mapping', function() {
+        analytics.track('User Signed Up');
+        analytics.called(window.pintrk, 'track', 'Signup');
+      });
+
+      it('should track product searched', function() {
+        analytics.track('Products Searched', { query: 'product1' });
+        analytics.called(window.pintrk, 'track', 'Search', {
+          search_query: 'product1'
+        });
+      });
+
+      it('should track product list filtered', function() {
+        analytics.track('Product List Filtered', {
+          category: 'cat 1'
+        });
+        analytics.called(window.pintrk, 'track', 'Search', {
+          line_items: [
+            {
+              product_category: 'cat 1'
+            }
+          ]
+        });
+      });
+
+      it('should track product added', function() {
+        analytics.track('Product Added', {
+          product_id: '507f1f77bcf86cd799439011',
+          currency: 'USD',
+          quantity: 1,
+          price: 44.33,
+          name: 'my product',
+          category: 'cat 1',
+          sku: 'p-298',
+          value: 24.75
+        });
+
+        analytics.called(window.pintrk, 'track', 'AddToCart', {
+          value: 24.75,
+          currency: 'USD',
+          line_items: [
+            {
+              product_name: 'my product',
+              product_id: 'p-298',
+              product_category: 'cat 1',
+              product_price: 44.33,
+              product_quantity: 1
+            }
+          ]
+        });
+      });
+
+      it('should tracks order completed', function() {
+        analytics.track('Order Completed', {
+          order_id: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              product_id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games'
+            },
+            {
+              product_id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Uno Card Game',
+              price: 3,
+              quantity: 2,
+              category: 'Games'
+            }
+          ]
+        });
+
+        analytics.called(window.pintrk, 'track', 'Checkout', {
+          order_id: '50314b8e9bcf000000000000',
+          coupon: 'hasbros',
+          currency: 'USD',
+          line_items: [
+            {
+              product_name: 'Monopoly: 3rd Edition',
+              product_id: '45790-32',
+              product_category: 'Games',
+              product_price: 19,
+              product_quantity: 1
+            },
+            {
+              product_name: 'Uno Card Game',
+              product_id: '46493-32',
+              product_category: 'Games',
+              product_price: 3,
+              product_quantity: 2
+            }
+          ]
+        });
+      });
+
+      it('should track video playback started', function() {
+        analytics.track('Video Playback Started');
+        analytics.called(window.pintrk, 'track', 'WatchVideo');
+      });
     });
 
     describe('#page', function() {

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -92,5 +92,28 @@ describe('Pinterest', function() {
         });
       });
     });
+
+    describe('#track', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'pintrk');
+      });
+
+      it('should track product viewed as page viewed', function() {
+        analytics.track('Product Viewed', {
+          id: '507f1f77bcf86cd799439011',
+          name: 'Monopoly: 3rd Edition',
+          price: 18.99
+        });
+
+        analytics.called(window.pintrk, 'track', 'PageVisit', {
+          line_items: [
+            {
+              product_name: 'Monopoly: 3rd Edition',
+              product_price: 18.99
+            }
+          ]
+        });
+      });
+    });
   });
 });

--- a/integrations/pinterest-tag/test/index.test.js
+++ b/integrations/pinterest-tag/test/index.test.js
@@ -115,5 +115,28 @@ describe('Pinterest', function() {
         });
       });
     });
+
+    describe('#page', function() {
+      beforeEach(function() {
+        analytics.stub(window, 'pintrk');
+      });
+
+      it('should track pagevisit for named page view', function() {
+        analytics.page('Page1');
+
+        analytics.called(window.pintrk, 'track', 'PageVisit', {
+          name: 'Page1'
+        });
+      });
+
+      it('should track viewcategory for categorised page view', function() {
+        analytics.page('Page1', 'Category');
+
+        analytics.called(window.pintrk, 'track', 'ViewCategory', {
+          category: 'Page1',
+          name: 'Category'
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
**What does this PR do?**
Add mapping to pinterest destination.

**Are there breaking changes in this PR?**
No.

**Any background context you want to provide?**
Currently, the Segment integration is not sending Page Viewed events for Products Viewed at all, so what would need to be done is to add the call for the Product Viewed event to call our Page Visit Event w/ a Product ID. 

**Is there parity with the server-side/android/iOS integration components (if applicable)?**
No.

**Does this require a new integration setting? If so, please explain how the new setting works**
No.

**Links to helpful docs and other external resources**
https://segment.com/docs/connections/destinations/catalog/pinterest-tag/#segment-event-mapping-to-pinterest-event-types